### PR TITLE
untrack jsx components by default

### DIFF
--- a/src/jsx.luau
+++ b/src/jsx.luau
@@ -69,7 +69,7 @@ local function jsx(tag: string | (Props) -> any, props: Props, ...): any
     end
 
     return untrack(function()
-        tag(props)
+        return tag(props)
     end)
 end
 

--- a/src/jsx.luau
+++ b/src/jsx.luau
@@ -2,6 +2,7 @@ local action = require(script.Parent.action)()
 local changed = require(script.Parent.changed)
 local create = require(script.Parent.create)
 local tags = require(script.Parent.tags)
+local untrack = require(script.Parent.untrack)
 
 type Props = { [any]: any }
 
@@ -67,7 +68,7 @@ local function jsx(tag: string | (Props) -> any, props: Props, ...): any
         props.children = ...
     end
 
-    return tag(props)
+    return untrack(function() tag(props) end)
 end
 
 return jsx

--- a/src/jsx.luau
+++ b/src/jsx.luau
@@ -68,7 +68,9 @@ local function jsx(tag: string | (Props) -> any, props: Props, ...): any
         props.children = ...
     end
 
-    return untrack(function() tag(props) end)
+    return untrack(function()
+        tag(props)
+    end)
 end
 
 return jsx


### PR DESCRIPTION
In SolidJS [jsx components are untracked](https://github.com/solidjs/solid/blob/main/packages/solid/src/render/component.ts#L111). I think the same should be true with Vide